### PR TITLE
Adds bridge IP and cidr for docker network

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,5 @@ default['amazon-ecs-agent']['docker_additional_binds'] = []
 default['amazon-ecs-agent']['docker_additional_envs'] = [
     'ECS_ENABLE_TASK_IAM_ROLE=true'
 ]
+default['amazon-ecs-agent']['fixed_cidr'] = '10.192.0.0/16'
+default['amazon-ecs-agent']['bip'] = '10.192.0.1/16'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,8 @@ end
 
 # create the docker service
 docker_service 'default' do
+  fixed_cidr node['amazon-ecs-agent']['fixed_cidr']
+  bip node['amazon-ecs-agent']['bip']
   storage_driver node['amazon-ecs-agent']['storage_driver']
   action [:create, :start]
 end


### PR DESCRIPTION
## [DEV-20195](https://curalate.atlassian.net/browse/DEV-20195)

#### What does this PR do?
This PR adds the bip and cidr ip range options to the internal fork of the `chef-amazon-ecs-agent` cookbook.  This will allow us to specify the internal network and container host bridge IP to use for centralizing services like dogstatsd

#### Screenshots
_(not applicable)_

#### Testing done before PR? 
Tested end to end build on new jenkins job

#### Testing planned in staging?
_(not applicable)_

#### Additional areas of concern?
None