### PR TITLE
DEV-28515: ECS AMI build fails due to outdated Docker install code

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,12 +6,10 @@ default['amazon-ecs-agent']['cluster'] = 'default'
 default['amazon-ecs-agent']['tag'] = 'latest'
 default['amazon-ecs-agent']['user'] = 'ubuntu'
 default['amazon-ecs-agent']['storage_driver'] = 'overlay'
-default['amazon-ecs-agent']['docker']['version'] = '1.11.2'
-default['amazon-ecs-agent']['docker']['apt']['keyserver'] = 'hkp://p80.pool.sks-keyservers.net:80'
-default['amazon-ecs-agent']['docker']['apt']['key'] = '58118E89F3A912897C070ADBF76221572C52609D'
+default['amazon-ecs-agent']['docker']['version'] = '17.05.0'
 default['amazon-ecs-agent']['docker_additional_binds'] = []
 default['amazon-ecs-agent']['docker_additional_envs'] = [
-    'ECS_ENABLE_TASK_IAM_ROLE=true'
+  'ECS_ENABLE_TASK_IAM_ROLE=true'
 ]
 default['amazon-ecs-agent']['fixed_cidr'] = '10.192.0.0/16'
 default['amazon-ecs-agent']['bip'] = '10.192.0.1/16'


### PR DESCRIPTION
The built-in installation no longer works with the Docker CE/EE
packaging changes. Replace it with shell script that uses the official,
familiar installation method.