### PR TITLE
DEV-34463 Add retry logic when starting ECS agent at boot

### DIFF
--- a/templates/default/run-ecs-agent.sh.erb
+++ b/templates/default/run-ecs-agent.sh.erb
@@ -1,14 +1,60 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-docker run \
-    --name ecs-agent \
-    --restart=always \
-    --volume=/var/run/docker.sock:/var/run/docker.sock \
-    --volume=<%= @log_folder %>:/log \
-    --volume=<%= @data_folder %>:/data \
-    --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
-    --volume=/var/run/docker/libcontainerd:/var/lib/libcontainerd:ro \
-    --net=host \
-    --env-file=<%= @env_file %> \
-    amazon/amazon-ecs-agent:<%= @tag %>
+# Launch the amazon-ecs-agent container to register this EC2 instance as part
+# of the ECS cluster defined in /etc/default/ecs-agent. The number of retries
+# and interval between retries both default to 10 but can be override via the
+# ECS_AGENT_MAX_RETRIES and ECS_AGENT_RETRY_INTERVAL variables set in that
+# file. If the agent cannot be started after the configured attempts a metric
+# is recorded in CloudWatch and the instance terminates.
+
+. /etc/default/ecs-agent
+
+ATTEMPT=0
+RETRIES=${ECS_AGENT_MAX_RETRIES:-10}
+INTERVAL=${ECS_AGENT_RETRY_INTERVAL:-10}
+CLOUDWATCH_NAMESPACE="${CLOUDWATCH_NAMESPACE:-Curalate/AutoScaling}"
+
+function start_agent() {
+    docker run \
+        -d \
+        --name ecs-agent \
+        --restart=always \
+        --volume=/var/run/docker.sock:/var/run/docker.sock \
+        --volume=<%= @log_folder %>:/log \
+        --volume=<%= @data_folder %>:/data \
+        --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+        --volume=/var/run/docker/libcontainerd:/var/lib/libcontainerd:ro \
+        --net=host \
+        --env-file=<%= @env_file %> \
+        amazon/amazon-ecs-agent:<%= @tag %>
+
+    return $?
+}
+
+function terminate() {
+    INSTANCE_ID=$(curl -s http://instance-data/latest/meta-data/instance-id)
+
+    aws cloudwatch put-metric-data \
+        --namespace $CLOUDWATCH_NAMESPACE \
+        --metric-name SelfTerminate \
+        --dimensions Application=ecs,Cluster=$ECS_CLUSTER,Reason=AgentLaunchFailure,InstanceID=$INSTANCE_ID \
+        --value 1 \
+        --unit Count
+
+    aws ec2 terminate-instances --instance-ids $INSTANCE_ID
+}
+
+until [ $ATTEMPT -ge $RETRIES ]; do
+    start_agent && break
+    ATTEMPT=$[$ATTEMPT+1]
+
+    echo "Retrying ECS agent container launch [$ATTEMPT/$RETRIES] in $INTERVAL(s)"
+    sleep $INTERVAL
+done
+
+if [ $ATTEMPT -ge $RETRIES ]; then
+    echo "Failed to start ECS agent container after $RETRIES attempts!"
+    terminate
+    exit 1
+fi


### PR DESCRIPTION
The ECS cluster instances use a `cloud-init` per_boot script to run the Amazon ECS Agent in a container on the instance. This agent is used to register the EC2 instance with the ECS service as part of the given cluster. If the agent fails to start the instance will stick around but never join the ECS cluster. We've had several occurrences now where the Docker daemon itself was not ready when the script kicked off:

```
Cloud-init v. 0.7.5 running 'modules:final' at Mon, 12 Feb 2018 20:22:20 +0000. Up 27.69 seconds.
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
2018-02-12 20:22:20,909 - util.py[WARNING]: Failed running /var/lib/cloud/scripts/per-boot/run-ecs-agent.sh [125]
2018-02-12 20:22:20,913 - cc_scripts_per_boot.py[WARNING]: Failed to run module scripts-per-boot (per-boot in /var/lib/cloud/scripts/per-boot)
2018-02-12 20:22:20,917 - util.py[WARNING]: Running scripts-per-boot (<module 'cloudinit.config.cc_scripts_per_boot' from '/usr/lib/python2.7/dist-packages/cloudinit/config/cc_scripts_per_boot.pyc'>) failed
```

This change adds some basic retry logic when starting the container at boot. The number of retries and interval between retries both default to 10 but can be override via the `ECS_AGENT_MAX_RETRIES` and `ECS_AGENT_RETRY_INTERVAL` variables set in the `/etc/default/ecs-agent` file. If the agent cannot be started after the configured attempts a metric is recorded in CloudWatch and the instance terminates. Harsh, but fair.

**Testing**
* [x] Overrides in `/etc/default/ecs-agent` work correctly
* [x] Retry limit is accurate
* [x] Container launches in happy path
* [x] CloudWatch metric recorded in sad path